### PR TITLE
Implement Sept 15 Meeting Feedback

### DIFF
--- a/docs/proposals/1374-multi-cluster-inference/README.md
+++ b/docs/proposals/1374-multi-cluster-inference/README.md
@@ -1,4 +1,4 @@
-# Multi-Cluster Inference
+# Multi-Cluster Inference Pooling
 
 Author(s): @danehans, @bexxmodd, @robscott
 
@@ -10,8 +10,8 @@ Author(s): @danehans, @bexxmodd, @robscott
 
 An Inference Gateway (IG) provides efficient routing to LLM workloads in Kubernetes by sending requests to an Endpoint Picker (EPP) associated with
 an [InferencePool](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/) and routing the request to a backend model server
-based on the EPP-provided endpoint. This proposal extends the current model to support multi-cluster routing so capacity in one cluster can serve
-traffic originating in another.
+based on the EPP-provided endpoint. Although other multi-cluster inference approaches may exist, this proposal extends the current model to support
+multi-cluster routing so capacity in one cluster can serve traffic originating in another cluster or outside the cluster.
 
 ### Why Multi-Cluster?
 
@@ -35,12 +35,12 @@ sustained demand, so a prescribed approach is required to share GPU capacity acr
 
 ## Design Proposal
 
-The Multi-Cluster Inference (MCI) model will largely follow the Multi-Cluster Services (MCS) model, with a few key differences:
+The Multi-Cluster Inference Pooling (MCIP) model will largely follow the Multi-Cluster Services (MCS) model, with a few key differences:
 
 - DNS and ClusterIP resolution will be omitted, e.g. ClusterSetIP.
 - A separate export resource will be avoided, e.g. ServiceExport, by inlining the concept within InferencePool.
 
-An InferencePoolImport resource is introduced that is meant to be fully managed by an MCI controller. This resource provides the information
+An InferencePoolImport resource is introduced that is meant to be fully managed by a controller. This resource provides the information
 required for IGs to route LLM requests to model server endpoints of an InferencePool in remote clusters. How the IG routes the request to the remote
 cluster is implementation-specific.
 
@@ -57,18 +57,16 @@ The proposal supports the following routing modes:
 
 1. **Export an InferencePool:** An [Inference Platform Owner](https://gateway-api-inference-extension.sigs.k8s.io/concepts/roles-and-personas/)
    exports an InferencePool by annotating it.
-2. **An MCI Controller (Per [ClusterSet](https://multicluster.sigs.k8s.io/api-types/cluster-set/)):**
-   - Watches all ClusterSet member clusters for exported InferencePool resources (must have access to the K8s API server).
+2. **Exporting Controller:**
+   - Watches exported InferencePool resources (must have access to the K8s API server).
    - CRUDs an InferencePoolImport in each member cluster if:
      - The cluster contains the namespace of the exported InferencePool (namespace sameness).
      - When an InferencePoolImport with the same ns/name already exists in the cluster, update the associated `inferencepoolimport.status.clusters[]` entry.
-   - Populates InferencePoolImport status with the information required for importing IGs to route requests to exported InferencePool endpoints,
-     e.g. address of the referenced EPP or remote parent so the importing IG can route to remote endpoints using either routing mode.
-3. **IG Management Plane (Per Cluster):**
+3. **Importing Controller:**
      - Watches InferencePoolImport resources.
      - Programs the managed IG data plane to either:
-       - Connect to the exported EPP via gRPC ext-proc for endpoint selection and optionally EPP health/metrics endpoints. Connect directly to exported
-         InferencePool endpoints (Endpoint Mode).
+       - Connect to the exported EPP via gRPC ext-proc for endpoint selection and optionally EPP metrics endpoint (Endpoint Mode).
+       - Connect directly to exported InferencePool endpoints (Endpoint Mode).
        - Connect to remote parents, e.g. IGs, of the exported InferencePool (Parent Mode).
 4. **Data Path:**
    The data path is dependant on the export mode selected by the user.
@@ -77,7 +75,7 @@ The proposal supports the following routing modes:
 
 ### InferencePoolImport Naming
 
-The MCI controller will create an InferencePoolImport resource using the exported InferencePool namespace and name. A cluster name entry in
+The exporting controller will create an InferencePoolImport resource using the exported InferencePool namespace and name. A cluster name entry in
 `inferencepoolimport.statu.clusters[]` is added for each cluster that exports an InferencePool with the same ns/name.
 
 ### InferencePool Selection
@@ -85,8 +83,7 @@ The MCI controller will create an InferencePoolImport resource using the exporte
 InferencePool selection is implementation-specific. The following are examples:
 
 - **Metrics-based:** Scrape EPP-exposed metrics (e.g., ready pods) to bias InferencePool choice.
-- **Health-based:** Basic readiness from EPP (gRPC health).
-- **Active-Passive:** Select the remote InferencePool when the local EPP fails.
+- **Active-Passive:** Basic EPP readiness checks (gRPC health).
 
 ### API Changes
 
@@ -102,125 +99,59 @@ inference.networking.x-k8s.io/export: "<value>"
 
 Supported Values:
 
-- `ClusterSet` – export to all members of the current ClusterSet.
+- `ClusterSet` – export to all members of the current [ClusterSet](https://multicluster.sigs.k8s.io/api-types/cluster-set/).
 
 **Note:** Additional annotations, e.g. region/domain scoping, filter clusters in the ClusterSet, routing mode configuration, etc. and
 potentially adding an InferencePoolExport resource may be considered in the future.
 
 #### InferencePoolImport
 
-A cluster-local, controller-managed resource that represents an imported InferencePool. It primarily communicates the EPP or parents of the
-exported InferencePool(s) to the importing IG controller. It is not user-authored; status carries the effective import. Inference Platform
-Owners can reference the InferencePoolImport, even if the local cluster does not have an InferencePool. In the context of Gateway API, it
-means that an HTTPRoute can be configured to reference an InferencePoolImport to route matching requests to remote InferencePool endpoints.
-This API will be used almost exclusively for tracking endpoints, but unlike MCS, we actually have two distinct sets of endpoints to track:
+A cluster-local, controller-managed resource that represents an imported InferencePool. It primarily communicates a relationship between an exported
+InferencePool and the exporting cluster name. It is not user-authored; status carries the effective import. Inference Platform Owners can reference the InferencePoolImport, even if the local cluster does not have an InferencePool. In the context of Gateway API, it means that an HTTPRoute can be configured to reference an InferencePoolImport to route matching requests to remote InferencePool endpoints. This API will be used almost exclusively for tracking endpoints,
+but unlike MCS, we actually have two distinct sets of endpoints to track:
 
 1. Endpoint Picker Extensions (EPPs)
 2. InferencePool parents, e.g. Gateways
 
 Key ideas:
 
+- Map exported InferencePool to exporting cluster name.
 - Name/namespace sameness with the exported InferencePool (avoids extra indirection).
-- Routing mode: whether the IG should route directly to remote EPP-selected endpoints or through parents of the exported InferencePool.
-- EPP details: network coordinates and optional health/metrics hints.
-- Conditions: Accepted, Ready, etc.
+- Conditions: Surface at least one condition, e.g. Accepted, to indicate to a user that the InferencePoolImport is ready to be used.
 
 See the full Go type below for additional details.
 
-#### (Optional) InferencePool Status Additions
-
-To reduce controller fan-out, InferencePool status should be updated to surface:
-
-- EPP Service details (type, IPs/hostnames, ports).
-- EPP health/metrics port numbers.
-- Optional secret references for metrics scraping or inter-cluster mTLS.
-
-(Tracked in Open Questions)
-
 ## Controller Responsibilities
 
-**MCI Controller (Per ClusterSet):**
+**Export Controller:**
 
 - Discover exported InferencePools.
 - For each ClusterSet member cluster, CRUD InferencePoolImport (mirrored namespace/name).
-- Populate `inferencepoolimport.status.clusters[]` entries with:
-  - EPP service address, ports, etc to support Endpoint Mode.
-  - Optional remote parents, e.g. Gateways, to support Parent Mode.
+- Populate `inferencepoolimport.status.clusters[]` entries with the cluster name associated with the exported InferencePool.
 
-**IG Controller (Per Cluster):**
+**Import Controller:**
 
 - Watch InferencePoolImports.
 - Program the IG data plane to either:
   - Connect to to remote EPPs and exported InferencePool endpoints (Endpoint Mode).
-  - Connect to exported parent(s) of the exported InferencePool (Parent Mode).
+  - Connect to parent(s) of the exported InferencePool (Parent Mode).
   - Load-balance matching requests.
 
 ## Examples
 
-The following diagram provides a high-level view of the MCI proposal:
-
-```mermaid
-flowchart LR
-  %% Layout
-  %% Nodes
-  CLIENT((Client))
-
-  subgraph MGMT["Management Cluster"]
-    MCI["MCI Controller"]
-  end
-
-  subgraph A["Workload Cluster A (exporting)"]
-    IPA["InferencePool"]
-    EPPA["EPP"]
-    PGA["Parent Gateway (optional)"]
-    PODA["Model Server Pod"]
-  end
-
-  subgraph B["Workload Cluster B (importing)"]
-    IPIMP["InferencePoolImport"]
-    IGCTL["Inference Gateway<br/>(management plane)"]
-    IGB["Inference Gateway<br/>(dataplane)"]
-    IPL["InferencePool<br/>(export annotation)"]
-  end
-
-  %% Controller relationships (control plane)
-  MCI -. "creates/updates" .-> IPIMP
-  IGCTL -. "watches" .-> IPIMP
-  IGCTL -. "configure" .-> IGB
-
-  %% Side-channel (control) consultations to EPP (dashed)
-  IGB -. "gRPC ext-proc (EndpointMode)" .-> EPPA
-  PGA -. "gRPC ext-proc" .-> EPPA
-
-  %% HTTP data paths (solid)
-  CLIENT --> IGB
-
-  %% Option A: EndpointMode
-  IGB -- "HTTP (EndpointMode)" --> PODA
-
-  %% Option B: ParentMode (via remote parent gateway)
-  IGB -- "HTTP (ParentMode)" --> PGA
-  PGA -- "HTTP" --> PODA
-
-  %% (Visual grouping / hints)
-  IPA --- PODA
-  IPA --- EPPA
-```
-
 ### Exporting Cluster (Cluster A) Manifests
 
 In this example, Cluster A exports the InferencePool to all clusters in the Cluster set using Endpoint Mode. This will
-cause the MCI controller to create an InferencePoolImport resource in all clusters.
+cause the exporting controller to create an InferencePoolImport resource in all clusters.
 
 ```yaml
-# Export the pool by annotation
 apiVersion: inference.networking.k8s.io/v1
 kind: InferencePool
 metadata:
   name: llm-pool
   namespace: example
   annotations:
-    inference.networking.x-k8s.io/export: "ClusterSet"
+    inference.networking.x-k8s.io/export: "ClusterSet" # Export the pool to all clusters in the ClusterSet
 spec:
   endpointPickerRef:
     name: epp
@@ -231,7 +162,6 @@ spec:
   targetPorts:
   - number: 8080
 ---
-# EPP exposed via LoadBalancer
 apiVersion: v1
 kind: Service
 metadata:
@@ -245,20 +175,14 @@ spec:
     port: 9002
     targetPort: 9002
     appProtocol: http2
-  - name: health
-    port: 9003
-    targetPort: 9003
-  - name: metrics
-    port: 9090
-    targetPort: 9090
-  type: LoadBalancer
+  type: LoadBalancer # EPP exposed via LoadBalancer
 ```
 
 ### Importing Cluster (Cluster B) Manifests
 
 In this example, the InferencePlatform Owner has configured an HTTPRoute to route to endpoints of the Cluster A InferencePool
 by referencing the InferencePoolImport as a `backendRef`. The parent IG(s) of the HTTPRoute are responsible for routing to the
-endpoints selected by the EPP referenced by the exported InferencePool (surfaced through InferencePoolImport status).
+endpoints selected by the EPP referenced by the exported InferencePool.
 
 The InferencePoolImport is controller-managed; shown here only to illustrate the expected status shape.
 
@@ -271,27 +195,8 @@ metadata:
 status:
   clusters:
   - name: cluster-a
-    targetPortNumber: 8080
-    endpointPicker:
-     name: epp
-     service:
-       addresses:
-       - 1.2.3.4      # EPP service address (IP or hostname)
-       port: 9002     # EPP ext-proc port
-     health:
-       port: 9003
-     metrics:
-       port: 9090
-    parents:
-    - name: parent1
-      namespace: foo
-      addresses:
-      - 5.6.7.8       # Remote parent address (IP or hostname)
-      port: 8080
   conditions:
   - type: Accepted
-    status: "True"
-  - type: Ready
     status: "True"
   observedGeneration: 1
 ---
@@ -371,7 +276,6 @@ type InferencePoolImportStatus struct {
 
     // Conditions include:
     // - Accepted: controller synthesized a valid import.
-    // - Ready: at least one EPP/parent is ready.
     //
     // +kubebuilder:validation:Optional
     Conditions []metav1.Condition `json:"conditions,omitempty"`
@@ -384,96 +288,9 @@ type InferencePoolImportStatus struct {
 
 type ImportedCluster struct {
     // Name of the exporting cluster (must be unique within the list). 
-    // Its values must map one to one to `ClusterProfile` names defined by the
-[ClusterProfile API](https://github.com/kubernetes/enhancements/pull/4322).
     //
     // +kubebuilder:validation:Required
     Name string `json:"name"`
-
-    // TargetPortNumber is the port the model servers listen on in the exported pool.
-    // Used when RoutingMode=EndpointMode.
-    //
-    // +kubebuilder:validation:Required
-    TargetPortNumber int32 `json:"targetPortNumber"`
-
-    // EndpointPicker describes how to connect to the EPP in the exporting cluster.
-    // Used when RoutingMode=EndpointMode.
-    //
-    // +kubebuilder:validation:Optional
-    EndpointPicker EndpointPickerImport `json:"endpointPicker,omitempty"`
-
-    // Parents describes optional "parent" frontends (e.g., Gateways) to route through
-    // when RoutingMode=ParentMode.
-    //
-    // +kubebuilder:validation:Optional
-    Parents []ParentImport `json:"parents,omitempty"`
-
-    // Conditions for cluster-scoped readiness (e.g., per-cluster EPP health).
-    Conditions []metav1.Condition `json:"conditions,omitempty"`
-}
-
-type EndpointPickerImport struct {
-    // Name of the EPP (informational).
-    //
-    // +kubebuilder:validation:Required
-    Name string `json:"name"`
-
-    // Service endpoints (addresses + ports) where the EPP exposes ext-proc.
-    //
-    // +kubebuilder:validation:Required
-    Service []ServiceImport `json:"service"`
-
-    // Health endpoint (optional) of the exported EPP.
-    //
-    // +kubebuilder:validation:Optional
-    Health *HealthEndpoint `json:"health,omitempty"`
-
-    // Metrics endpoint (optional) of the exported EPP.
-    //
-    // +kubebuilder:validation:Optional
-    Metrics *MetricsEndpoint `json:"metrics,omitempty"`
-}
-
-// ParentImport models a remote "parent" (typically a Gateway Service) that fronts
-// the imported InferencePool.
-type ParentImport struct {
-    // Name of the remote parent (informational).
-    //
-    // +kubebuilder:validation:Required
-    Name string `json:"name"`
-    // Namespace of the remote parent (informational).
-    //
-    // +kubebuilder:validation:Required
-    Namespace  string `json:"namespace"`
-    // Addresses supports IPs and/or hostnames of the remote parent.
-    //
-    // +kubebuilder:validation:Required
-    Addresses []string `json:"addresses"`
-
-    // Port is the network port exposed by the remote parent.
-    //
-    // +kubebuilder:validation:Required
-    Port Port `json:"port"`
-}
-
-type ServiceImport struct {
-    // Addresses supports IPs and/or hostnames of the remote service.
-    //
-    // +kubebuilder:validation:Required
-    Addresses []string `json:"addresses"`
-
-    // Port is the network port exposed by the remote EPP service.
-    //
-    // +kubebuilder:validation:Required
-    Port Port `json:"port"`
-}
-
-type HealthEndpoint struct {
-    Port int32  `json:"port"`
-}
-
-type MetricsEndpoint struct {
-    Port int32 `json:"port"`
 }
 
 // +kubebuilder:object:root=true
@@ -508,7 +325,7 @@ requires a separate MCS parent export for parent-based inter-cluster routing.
 **Cons**:
 
 - Referencing InferencePools in other clusters requires you to create an InferencePool locally.
-- In this model, you don’t actually choose to export an InferencePool, you export the EPP or InferencePool parent(s) service, that could lead to significant confusion.
+- In this model, you don’t actually choose to export an InferencePool, you export the EPP or InferencePool parent(s) service, that could lead to confusion.
 - InferencePool is meant to be a replacement for a Service so it may seem counterintuitive for a user to create a Service to achieve multi-cluster inference.
 
 ## Option 2: New MCS API
@@ -553,7 +370,7 @@ status:
 #### Security
 
 - Provide a standard way to bootstrap mTLS between importing IG and exported EPP/parents, e.g. use BackendTLSPolicy?
-- Should the MCI controller mirror secrets into the importing cluster, e.g. secure metric scraping (Endpoint Mode)?
+- Should the export controller mirror secrets into the importing cluster, e.g. secure metric scraping (Endpoint Mode)?
 
 #### Scheduling and Policy
 
@@ -561,12 +378,11 @@ status:
 
 #### EPP Scale
 
-- If the EPP has multiple replicas, should the MCI controller publish per-replica addresses, e.g. service subsetting, for health/metrics scraping?
+- If the EPP has multiple replicas, should the export controller publish per-replica addresses, e.g. service subsetting, for health/metrics scraping?
 
 #### Ownership and Lifecycle
 
-- Should the MCI controller be owned by the Gateway API Inference Extension project?
-- What happens if the importing namespace doesn’t exist? Should the MCI controller skip or optionally create it? Introducing an InferencePoolExport resource instead of annotations could help resolve this issue.
+- What happens if the importing namespace doesn’t exist? Should the export controller surface a status condition in the exported InferencePool?
 - Garbage collection when export is withdrawn (delete import?) and how to drain traffic safely.
 
 ### Prior Art


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

Implements feedback from the 9/15/24 community meeting.

- Reduces InferencePoolImport status to a list of cluster names and status conditions.
- Renames the title.
- Removes MCI controller language.

**What type of PR is this?**
Add one of the following kinds:
/kind documentation

**What this PR does / why we need it**:

Iterates the MCIP design proposal based on community feedback.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
